### PR TITLE
Allow any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,12 +27,13 @@ source "https://rubygems.org" do
   gem "faraday",             "~> 1.0", :require => false
   gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
   gem "net-http-persistent", "~> 4.0", :require => false
-  if RUBY_VERSION.start_with?("2.3") then
-    gem "nokogiri",            "~> 1.10.4", :require => false
+  if RUBY_VERSION < "2.4.0"
+    gem "nokogiri",          "~> 1.10.4", :require => false
+  elsif RUBY_VERSION < "2.5.0"
+    gem "nokogiri",          "~> 1.11.0.rc2", :require => false
   else
-    gem "nokogiri",            "~> 1.11.0.rc2", :require => false
+    gem "nokogiri",          "~> 1", ">= 1.12.5", :require => false
   end
-
   gem "adal",                "~> 1.0", :require => false
   gem "dotenv",              "~> 2.0", :require => false
   gem "minitest",            "~> 5", :require => false

--- a/blob/ChangeLog.md
+++ b/blob/ChangeLog.md
@@ -1,3 +1,6 @@
+2021.10 - version 2.0.2
+* Allow to use any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0.
+
 2020.8 - version 2.0.1
 * Bumped up Nokogiri version to 1.11.0.rc2 for Ruby version later than or equal to 2.4.0.
 

--- a/blob/azure-storage-blob.gemspec
+++ b/blob/azure-storage-blob.gemspec
@@ -43,10 +43,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("azure-storage-common",    "~> 2.0")
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
-  else
+  elsif RUBY_VERSION < "2.5.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+  else
+    s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.12.5")
   end
-
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")
   s.add_development_dependency("minitest-reporters",  "~> 1")

--- a/blob/lib/azure/storage/blob/version.rb
+++ b/blob/lib/azure/storage/blob/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 1 unless defined? UPDATE
+        UPDATE = 2 unless defined? UPDATE
 
         class << self
           # @return [String]

--- a/common/ChangeLog.md
+++ b/common/ChangeLog.md
@@ -1,3 +1,6 @@
+2021.10 - version 2.0.3
+* Allow to use any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0.
+
 2020.8 - version 2.0.2
 * Bumped up Nokogiri version to 1.11.0.rc2 for Ruby version later than or equal to 2.4.0.
 * Changed to use persistent HTTP client to speed up requests #168.

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
   else
-    s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+    s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.12.5")
   end
 
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/common/lib/azure/storage/common/version.rb
+++ b/common/lib/azure/storage/common/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 2 unless defined? UPDATE
+        UPDATE = 3 unless defined? UPDATE
 
         class << self
           # @return [String]

--- a/file/ChangeLog.md
+++ b/file/ChangeLog.md
@@ -1,3 +1,6 @@
+2021.10 - version 2.0.3
+* Allow to use any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0.
+
 2020.8 - version 2.0.2
 * Bumped up Nokogiri version to 1.11.0.rc2 for Ruby version later than or equal to 2.4.0.
 

--- a/file/azure-storage-file.gemspec
+++ b/file/azure-storage-file.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
   else
-    s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+    s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.12.5")
   end
 
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/file/lib/azure/storage/file/version.rb
+++ b/file/lib/azure/storage/file/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 2 unless defined? UPDATE
+        UPDATE = 3 unless defined? UPDATE
 
         class << self
           # @return [String]

--- a/queue/ChangeLog.md
+++ b/queue/ChangeLog.md
@@ -1,3 +1,6 @@
+2021.10 - version 2.0.3
+* Allow to use any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0.
+
 2020.8 - version 2.0.2
 * Bumped up Nokogiri version to 1.11.0.rc2 for Ruby version later than or equal to 2.4.0.
 

--- a/queue/azure-storage-queue.gemspec
+++ b/queue/azure-storage-queue.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
   else
-    s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+    s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.12.5")
   end
 
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/queue/lib/azure/storage/queue/version.rb
+++ b/queue/lib/azure/storage/queue/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 2 unless defined? UPDATE
+        UPDATE = 3 unless defined? UPDATE
 
         class << self
           # @return [String]

--- a/table/ChangeLog.md
+++ b/table/ChangeLog.md
@@ -1,3 +1,6 @@
+2021.10 - version 2.0.3
+* Allow to use any version 1.x of Nokogiri for Ruby version later than or equal to 2.5.0.
+
 2020.8 - version 2.0.2
 * Bumped up Nokogiri version to 1.11.0.rc2 for Ruby version later than or equal to 2.4.0.
 

--- a/table/azure-storage-table.gemspec
+++ b/table/azure-storage-table.gemspec
@@ -43,10 +43,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("azure-storage-common",    "~> 2.0")
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
-  else
+  elsif RUBY_VERSION < "2.5.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+  else
+    s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.12.5")
   end
-
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")
   s.add_development_dependency("minitest-reporters",  "~> 1")

--- a/table/lib/azure/storage/table/version.rb
+++ b/table/lib/azure/storage/table/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 2 unless defined? UPDATE
+        UPDATE = 3 unless defined? UPDATE
 
         class << self
           # @return [String]


### PR DESCRIPTION
### Summary

Bumps the nokogiri version. Nokogiri >= 1.12.5 is required for rails 6 updates. This is to unblock us until the PR is merged on the original gem: https://github.com/Azure/azure-storage-ruby/pull/199. The PR has been approved but is taking a while to get released by Azure.

### Risk
Low risk. 
- Security risk assessment: Loosening the restriction on nokogiri actually lets us update nokogiri to a recent version which mitigates a major security vulnerability ([cve](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2rr5-8q37-2w7h)). Using our own fork so we aren't pointing our dependencies to a public fork which could change.
- General risk assessment: This is just a temporary fix meant to unblock us from development work for the rails 6 updates. Once the original is released we will point our gemfile back to it. At this point, we don't plan to deploy the app to production using this fork. If we do, we won't see updated releases without maintaining this fork but considering the last official release was 8/2020 I still see this as low risk.